### PR TITLE
Drop FW Fixes for massdrop alt, ctrl, rocketeer & shift keyboards

### DIFF
--- a/keyboards/massdrop/alt/config.h
+++ b/keyboards/massdrop/alt/config.h
@@ -94,6 +94,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
 
+// Required BOOT key hold time (in ms) for restarting to bootloader -PS081419
+#define BOOTKEY_HOLD_MS		2000
+
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 //#define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */

--- a/keyboards/massdrop/alt/keymaps/default/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/default/keymap.c
@@ -84,7 +84,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 key_timer = timer_read32();
             } else {
-                if (timer_elapsed32(key_timer) >= 500) {
+                if (timer_elapsed32(key_timer) >= BOOTKEY_HOLD_MS) {
                     reset_keyboard();
                 }
             }

--- a/keyboards/massdrop/alt/keymaps/default_md/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/default_md/keymap.c
@@ -231,7 +231,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 key_timer = timer_read32();
             } else {
-                if (timer_elapsed32(key_timer) >= 500) {
+                if (timer_elapsed32(key_timer) >= BOOTKEY_HOLD_MS) {
                     reset_keyboard();
                 }
             }

--- a/keyboards/massdrop/alt/keymaps/mac/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/mac/keymap.c
@@ -84,7 +84,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 key_timer = timer_read32();
             } else {
-                if (timer_elapsed32(key_timer) >= 500) {
+                if (timer_elapsed32(key_timer) >= BOOTKEY_HOLD_MS) {
                     reset_keyboard();
                 }
             }

--- a/keyboards/massdrop/alt/keymaps/mac_md/keymap.c
+++ b/keyboards/massdrop/alt/keymaps/mac_md/keymap.c
@@ -231,7 +231,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 key_timer = timer_read32();
             } else {
-                if (timer_elapsed32(key_timer) >= 500) {
+                if (timer_elapsed32(key_timer) >= BOOTKEY_HOLD_MS) {
                     reset_keyboard();
                 }
             }

--- a/keyboards/massdrop/ctrl/config.h
+++ b/keyboards/massdrop/ctrl/config.h
@@ -94,6 +94,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
 
+// Required BOOT key hold time (in ms) for restarting to bootloader -PS081419
+#define BOOTKEY_HOLD_MS		2000
+
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 //#define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */

--- a/keyboards/massdrop/ctrl/keymaps/default/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/default/keymap.c
@@ -87,7 +87,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 key_timer = timer_read32();
             } else {
-                if (timer_elapsed32(key_timer) >= 500) {
+                if (timer_elapsed32(key_timer) >= BOOTKEY_HOLD_MS) {
                     reset_keyboard();
                 }
             }

--- a/keyboards/massdrop/ctrl/keymaps/default_md/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/default_md/keymap.c
@@ -234,7 +234,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 key_timer = timer_read32();
             } else {
-                if (timer_elapsed32(key_timer) >= 500) {
+                if (timer_elapsed32(key_timer) >= BOOTKEY_HOLD_MS) {
                     reset_keyboard();
                 }
             }

--- a/keyboards/massdrop/ctrl/keymaps/mac/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/mac/keymap.c
@@ -87,7 +87,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 key_timer = timer_read32();
             } else {
-                if (timer_elapsed32(key_timer) >= 500) {
+                if (timer_elapsed32(key_timer) >= BOOTKEY_HOLD_MS) {
                     reset_keyboard();
                 }
             }

--- a/keyboards/massdrop/ctrl/keymaps/mac_md/keymap.c
+++ b/keyboards/massdrop/ctrl/keymaps/mac_md/keymap.c
@@ -234,7 +234,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 key_timer = timer_read32();
             } else {
-                if (timer_elapsed32(key_timer) >= 500) {
+                if (timer_elapsed32(key_timer) >= BOOTKEY_HOLD_MS) {
                     reset_keyboard();
                 }
             }

--- a/keyboards/massdrop/rocketeer/config.h
+++ b/keyboards/massdrop/rocketeer/config.h
@@ -95,6 +95,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
 
+// Required BOOT key hold time (in ms) for restarting to bootloader -PS081419
+#define BOOTKEY_HOLD_MS		2000
+
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 //#define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */

--- a/keyboards/massdrop/rocketeer/keymaps/default_md/keymap.c
+++ b/keyboards/massdrop/rocketeer/keymaps/default_md/keymap.c
@@ -231,7 +231,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 key_timer = timer_read32();
             } else {
-                if (timer_elapsed32(key_timer) >= 500) {
+                if (timer_elapsed32(key_timer) >= BOOTKEY_HOLD_MS) {
                     reset_keyboard();
                 }
             }

--- a/keyboards/massdrop/rocketeer/keymaps/mac_md/keymap.c
+++ b/keyboards/massdrop/rocketeer/keymaps/mac_md/keymap.c
@@ -231,7 +231,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 key_timer = timer_read32();
             } else {
-                if (timer_elapsed32(key_timer) >= 500) {
+                if (timer_elapsed32(key_timer) >= BOOTKEY_HOLD_MS) {
                     reset_keyboard();
                 }
             }

--- a/keyboards/massdrop/shift/config.h
+++ b/keyboards/massdrop/shift/config.h
@@ -125,6 +125,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
 #define DEBOUNCE 5
 
+// Required BOOT key hold time (in ms) for restarting to bootloader -PS081419
+#define BOOTKEY_HOLD_MS		2000
+
 /* Mechanical locking support. Use KC_LCAP, KC_LNUM or KC_LSCR instead in keymap */
 //#define LOCKING_SUPPORT_ENABLE
 /* Locking resynchronize hack */

--- a/keyboards/massdrop/shift/keymaps/default_md/keymap.c
+++ b/keyboards/massdrop/shift/keymaps/default_md/keymap.c
@@ -243,7 +243,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 key_timer = timer_read32();
             } else {
-                if (timer_elapsed32(key_timer) >= 500) {
+                if (timer_elapsed32(key_timer) >= BOOTKEY_HOLD_MS) {
                     reset_keyboard();
                 }
             }

--- a/keyboards/massdrop/shift/keymaps/mac_md/keymap.c
+++ b/keyboards/massdrop/shift/keymaps/mac_md/keymap.c
@@ -243,7 +243,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             if (record->event.pressed) {
                 key_timer = timer_read32();
             } else {
-                if (timer_elapsed32(key_timer) >= 500) {
+                if (timer_elapsed32(key_timer) >= BOOTKEY_HOLD_MS) {
                     reset_keyboard();
                 }
             }

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -647,6 +647,7 @@ bool process_record_quantum(keyrecord_t *record) {
             #endif
             break;
           case MAGIC_TOGGLE_NKRO:
+            clear_keyboard();   // clear first buffer to prevent stuck keys -PS080919
             keymap_config.nkro = !keymap_config.nkro;
             break;
           default:


### PR DESCRIPTION
- In config.h of each, added '#define BOOTKEY_HOLD_MS  2000' to define hold time required to active Boot key (was 500ms hardcode)
- Updated all active keymap.c files to use this define
- Added line in quantum.c in MAGIC_TOGGLE_NKRO case to clear_keyboard() before toggling nkro state to fix stuck key issues when switching NKRO.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
