### PR TITLE
Disable QMK CLI XAP commands because of weird error when running as root

### DIFF
--- a/lib/python/qmk/cli/__init__.py
+++ b/lib/python/qmk/cli/__init__.py
@@ -77,11 +77,11 @@ subcommands = [
     'qmk.cli.pyformat',
     'qmk.cli.pytest',
     'qmk.cli.via2json',
-    'qmk.cli.xap',
-    'qmk.cli.xap.generate_docs',
-    'qmk.cli.xap.generate_json',
-    'qmk.cli.xap.generate_python',
-    'qmk.cli.xap.generate_qmk',
+#    'qmk.cli.xap',
+#    'qmk.cli.xap.generate_docs',
+#    'qmk.cli.xap.generate_json',
+#    'qmk.cli.xap.generate_python',
+#    'qmk.cli.xap.generate_qmk',
 ]
 
 


### PR DESCRIPTION
On the kbcfg instances, we're running into an error when trying to invoke the QMK CLI as root:
```
root@md-coresite-kbcfg-staging-0c5cc30ff7ca73147:/var/app/md-kbcfg# qmk
Traceback (most recent call last):
  File "/usr/local/bin/qmk", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/dist-packages/qmk_cli/script_qmk.py", line 76, in main
    import qmk.cli  # noqa
  File "/var/app/md-kbcfg/qmk_firmware_riot/lib/python/qmk/cli/__init__.py", line 247, in <module>
    __import__(subcommand)
  File "/var/app/md-kbcfg/qmk_firmware_riot/lib/python/qmk/cli/xap/__init__.py", line 1, in <module>
    from .xap import xap
  File "/var/app/md-kbcfg/qmk_firmware_riot/lib/python/qmk/cli/xap/xap.py", line 10, in <module>
    from xap_client import XAPClient, XAPEventType, XAPSecureStatus
  File "/var/app/md-kbcfg/qmk_firmware_riot/lib/python/xap_client/__init__.py", line 4, in <module>
    from .client import *  # noqa: F403
  File "/var/app/md-kbcfg/qmk_firmware_riot/lib/python/xap_client/client.py", line 3, in <module>
    import hid
  File "/usr/local/lib/python3.8/dist-packages/hid/__init__.py", line 83, in <module>
    hidapi.hid_get_input_report.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_size_t]
  File "/usr/lib/python3.8/ctypes/__init__.py", line 386, in __getattr__
    func = self.__getitem__(name)
  File "/usr/lib/python3.8/ctypes/__init__.py", line 391, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: /lib/x86_64-linux-gnu/libhidapi-hidraw.so.0: undefined symbol: hid_get_input_report
```

This error prevents compilation from our web configurator. The weird thing is that when not running as root, the error doesn't happen.

As a short-term fix, I'm disabling XAP commands specifically for the branch we will use on kbcfg instances. When dev'ing locally, you shouldn't use this branch.